### PR TITLE
Added link to CommunityJS rawdata repository in the footer

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -55,4 +55,6 @@
         This is the content of passed
     #footer
       | Want to add/change a group?
-      a(href="https://groups.google.com/group/communityjs/") Let us know!
+      a(href="https://github.com/CommunityJS/CommunityJSData") Send us a pull request
+      |  or
+      a(href="https://groups.google.com/group/communityjs/") let us know!


### PR DESCRIPTION
It seems that a few people keep asking for updates/additions via the Google Group. I also had to read the mailing list carefully to learn about the rawdata repository.  

Handling the groups data through Github is great so I thought that it would be nice to add a link in the footer to let people know about it.

Cheers,
Olivier.
